### PR TITLE
dependencies: remove 'lodash.get'

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let get = require('lodash.get');
 let plurals = require('./plurals');
 
 class Gettext {
@@ -443,7 +442,7 @@ class Gettext {
     _getTranslation(locale, domain, msgctxt, msgid) {
         msgctxt = msgctxt || '';
 
-        return get(this.catalogs, [locale, domain, 'translations', msgctxt, msgid]);
+        return this.catalogs?.[locale]?.[domain]?.translations?.[msgctxt]?.[msgid];
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
         "": {
             "name": "@postalsys/gettext",
             "version": "4.1.0",
-            "dependencies": {
-                "lodash.get": "4.4.2"
-            },
             "devDependencies": {
                 "chai": "4.4.1",
                 "eslint": "8.57.0",
@@ -2748,6 +2745,7 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
             "url": "http://github.com/postalsys/gettext/blob/master/LICENSE"
         }
     ],
-    "dependencies": {
-        "lodash.get": "4.4.2"
-    },
     "devDependencies": {
         "chai": "4.4.1",
         "eslint": "8.57.0",


### PR DESCRIPTION
The NPM package repository website [indicates that this package is deprecated](https://www.npmjs.com/package/lodash.get), and that code should be migrated to use the optional chaining operator `?.` instead.

This changeset applies that change and removes the dependency.

cc @andris9